### PR TITLE
Incorrect "No generator named "X" is defined in the persistence unit" validation error #12

### DIFF
--- a/jpa/plugins/org.eclipse.jpt.jpa.core/src/org/eclipse/jpt/jpa/core/validation/JptJpaCoreValidationMessages.java
+++ b/jpa/plugins/org.eclipse.jpt.jpa.core/src/org/eclipse/jpt/jpa/core/validation/JptJpaCoreValidationMessages.java
@@ -339,6 +339,7 @@ public class JptJpaCoreValidationMessages {
 		PROJECT_INVALID_CONNECTION.setDefaultSeverity(IMessage.NORMAL_SEVERITY);
 		PROJECT_NO_CONNECTION.setDefaultSeverity(IMessage.NORMAL_SEVERITY);
 		TYPE_ANNOTATED_BUT_NOT_LISTED_IN_PERSISTENCE_XML.setDefaultSeverity(IMessage.NORMAL_SEVERITY);
+		UNRESOLVED_GENERATOR_NAME.setDefaultSeverity(IMessage.NORMAL_SEVERITY);
 
 		// INFOs
 		XML_VERSION_NOT_LATEST.setDefaultSeverity(IMessage.LOW_SEVERITY);


### PR DESCRIPTION
This fix will change the severity to Warning instead of Error.

Change-Id: I4539761e3025ca805e726d5325049403a1ce074e