### PR TITLE
Update to org.apache.velocity.engine-core 2.4.1

### DIFF
--- a/jpa/features/org.eclipse.jpt.jpa.feature/feature.xml
+++ b/jpa/features/org.eclipse.jpt.jpa.feature/feature.xml
@@ -117,7 +117,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.velocity"
+         id="org.apache.velocity.engine-core"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/jpa/features/org.eclipse.jpt.jpa.feature/pom.xml
+++ b/jpa/features/org.eclipse.jpt.jpa.feature/pom.xml
@@ -42,8 +42,8 @@
               <excludes>
                 <plugin id="javax.persistence"/>
                 <plugin id="org.apache.commons.collections"/>
-                <plugin id="org.apache.commons.lang"/>
-                <plugin id="org.apache.velocity"/>
+                <plugin id="org.apache.commons.lang3"/>
+                <plugin id="org.apache.velocity.engine-core"/>
                 <plugin id="org.eclipse.jpt.jpa.branding"/>
                 <plugin id="org.jdom"/>
               </excludes>

--- a/jpa/plugins/org.eclipse.jpt.jpa.gen/META-INF/MANIFEST.MF
+++ b/jpa/plugins/org.eclipse.jpt.jpa.gen/META-INF/MANIFEST.MF
@@ -19,12 +19,14 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.4.0,4.0.0)",
  org.apache.commons.collections;bundle-version="[3.2.2,4.0.0)",
- org.apache.commons.lang;bundle-version="[2.1.0,3.0.0)",
- org.apache.velocity;bundle-version="[1.5.0,2.0.0)",
+ org.apache.velocity.engine-core;bundle-version="[2.4.1,3.0.0)",
  org.jdom;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.wst.common.emf;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.emf.ecore.xmi;bundle-version="[2.5.0,3.0.0)",
- org.eclipse.core.filebuffers;bundle-version="[3.4.0,4.0.0)"
+ org.eclipse.core.filebuffers;bundle-version="[3.4.0,4.0.0)",
+ slf4j.simple;bundle-version="[2.0.0,3.0.0)",
+ slf4j.api;bundle-version="[2.0.0,3.0.0)",
+ org.apache.commons.lang3;bundle-version="[3.0.0,4.0.0)"
 Import-Package: com.ibm.icu.text
 Export-Package: org.eclipse.jpt.jpa.gen,
  org.eclipse.jpt.jpa.gen.internal;x-internal:=true,

--- a/jpa/plugins/org.eclipse.jpt.jpa.gen/src/org/eclipse/jpt/jpa/gen/internal/PackageGenerator.java
+++ b/jpa/plugins/org.eclipse.jpt.jpa.gen/src/org/eclipse/jpt/jpa/gen/internal/PackageGenerator.java
@@ -16,16 +16,14 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
-import org.apache.velocity.runtime.log.JdkLogChute;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.manipulation.ConvertLineDelimitersOperation;
@@ -69,7 +67,6 @@ import org.osgi.framework.Bundle;
  */
 public class PackageGenerator {
 
-	private static final String LOGGER_NAME = "org.eclipse.jpt.entities.gen.log"; //$NON-NLS-1$
 	private final JpaProject jpaProject;
 	private final ORMGenCustomizer customizer;
 	private final OverwriteConfirmer overwriteConfirmer;
@@ -290,23 +287,8 @@ public class PackageGenerator {
 					return;
 				}
 			}
-			//JdkLogChute in this version of Velocity not allow to set log level
-			//Workaround by preset the log level before Velocity is initialized
-			Logger logger = Logger.getLogger( LOGGER_NAME );
-			logger.setLevel( Level.SEVERE );
 
-			Properties vep = new Properties();
-			vep.setProperty("file.resource.loader.path", templateDirPath); //$NON-NLS-1$
-			vep.setProperty( JdkLogChute.RUNTIME_LOG_JDK_LOGGER, LOGGER_NAME );
-			VelocityEngine ve = new VelocityEngine();
-			//Massage TCCL to deal with bug in m2e - see 396554
-			ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
-			Thread.currentThread().setContextClassLoader(ve.getClass().getClassLoader());
-			try {
-		    	ve.init(vep);
-			} finally {
-				Thread.currentThread().setContextClassLoader(oldClassLoader);
-			}
+			VelocityEngine ve = createEngine(templateDirPath);
 
 		    sm.worked(2);
 
@@ -444,23 +426,8 @@ public class PackageGenerator {
 					return;
 				}
 			}
-			//JdkLogChute in this version of Velocity not allow to set log level
-			//Workaround by preset the log level before Velocity is initialized
-			Logger logger = Logger.getLogger( LOGGER_NAME );
-			logger.setLevel( Level.SEVERE );
 
-			Properties vep = new Properties();
-			vep.setProperty("file.resource.loader.path", templateDirPath); //$NON-NLS-1$
-			vep.setProperty( JdkLogChute.RUNTIME_LOG_JDK_LOGGER, LOGGER_NAME );
-			VelocityEngine ve = new VelocityEngine();
-			//Massage TCCL to deal with bug in m2e - 396554
-			ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
-			Thread.currentThread().setContextClassLoader(ve.getClass().getClassLoader());
-			try {
-		    	ve.init(vep);
-			} finally {
-				Thread.currentThread().setContextClassLoader(oldClassLoader);
-			}
+			VelocityEngine ve = createEngine(templateDirPath);
 
 			String charset = xmlFile.getCharset();
 			charset = checkCharsetAndFallbackToUTF8IfNecessary(charset);
@@ -554,4 +521,19 @@ public class PackageGenerator {
 		}
 	}
 
+	private static VelocityEngine createEngine(String templateDirPath) {
+		Properties vep = new Properties();
+		vep.setProperty("resource.loader.file.path", templateDirPath);
+		System.setProperty("org.slf4j.simpleLogger.log.org.apache.velocity", "error");
+		VelocityEngine ve = new VelocityEngine();
+		//Massage TCCL to deal with bug in m2e - see 396554
+		ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(ve.getClass().getClassLoader());
+		try {
+	    	ve.init(vep);
+		} finally {
+			Thread.currentThread().setContextClassLoader(oldClassLoader);
+		}
+		return ve;
+	}
 }


### PR DESCRIPTION
- Factor out engine creation.
- Ensure that slf4j logging is configured for error level.

https://github.com/eclipse-dali/webtools.dali/issues/21