### PR TITLE
Remove org.apache.commons.lang from org.eclipse.jpt.jpa.feature

### DIFF
--- a/jpa/features/org.eclipse.jpt.jpa.feature/feature.xml
+++ b/jpa/features/org.eclipse.jpt.jpa.feature/feature.xml
@@ -110,13 +110,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.lang"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.velocity.engine-core"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
- It is unused and has an associated CVE https://nvd.nist.gov/vuln/detail/CVE-2025-48924
- It will be removed from Orbit.